### PR TITLE
Remove an unnecessary waterMaskMap lookup

### DIFF
--- a/M4Revolution/Ubi.cpp
+++ b/M4Revolution/Ubi.cpp
@@ -1335,13 +1335,7 @@ namespace Ubi {
 
 						inputStream.seekg(maskFileSystemPosition + (std::streampos)maskFile.position);
 
-						waterMaskMapIterator = waterMaskMap.find(fileFaceStrMapIterator->second);
-
-						if (waterMaskMapIterator == waterMaskMap.end()) {
-							waterMaskMapIterator = waterMaskMap.insert({ fileFaceStrMapIterator->second, {} }).first;
-						}
-
-						Binary::RLE::appendToSliceMap(inputStream, maskFile.size, waterMaskMapIterator->second);
+						Binary::RLE::appendToSliceMap(inputStream, maskFile.size, waterMaskMap[fileFaceStrMapIterator->second]);
 					}
 				}
 			}


### PR DESCRIPTION
The find() + insert() default-constructed value can be replaced with operator[] to remove a lookup.

I don't have a machine with a toolchain that can build this project, but I'm 90% sure I didn't typo something silly. Hopefully.